### PR TITLE
make PLSE 6.4.1.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.apache.bcel</groupId>
   <artifactId>bcel</artifactId>
   <packaging>jar</packaging>
-  <version>6.4.2-SNAPSHOT</version>
+  <version>6.4.1.1</version>
   <name>Apache Commons BCEL</name>
   <description>Apache Commons Bytecode Engineering Library</description>
 
@@ -47,7 +47,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <commons.componentid>bcel</commons.componentid>
     <commons.module.name>org.apache.bcel</commons.module.name>
-    <commons.release.version>6.4.2</commons.release.version>
+    <commons.release.version>6.4.1.1</commons.release.version>
     <commons.release.isDistModule>true</commons.release.isDistModule>
     <commons.rc.version>RC1</commons.rc.version>
     <commons.bc.version>6.4.1</commons.bc.version>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -62,7 +62,11 @@ The <action> type attribute can be add,update,fix,remove.
    -->
 
   <body>
-    <release version="6.4.2" date="2019-MM-DD" description="Bug fix release.">
+    <release version="6.4.1.1" date="2020-02-24" description="University of Washington PLSE Bug fix release.">
+      <action                  type="update" due-to="Mark Roberts">Allow clients to manipulate Annotations.</action>
+      <action issue="BCEL-335" type="fix" due-to="Mark Roberts">fix jdk 11 javadoc error.</action>
+      <action issue="BCEL-334" type="update" due-to="Mark Roberts">Add attribute name headings to toString of a Code attribute.</action>
+      <action issue="BCEL-333" type="fix" due-to="Mark Roberts">InovokeStatic may refer to either a MethodRef or an InterfaceMethodRef.</action>
       <action issue="BCEL-330" type="update" dev="ggregory" due-to="Mark Roberts">Remove unnecessary references to Constants.</action>
       <action issue="BCEL-329" type="fix" dev="ggregory" due-to="Gary Gregory, Mark Roberts">MethodGen duplicates some attributes.</action>
       <action                  type="update" dev="ggregory" due-to="Gary Gregory">Update tests from JNA 5.4.0 to 5.5.0.</action>


### PR DESCRIPTION
This pull request identifies this as PLSE commons-bcel release 6.4.1.1. The last official Apache release is 6.4.1. This version has three changes to support Daikon on jdk11:

src/main/java/org/apache/bcel/generic/MethodGen.java to improve Attribute support
src/main/java/org/apache/bcel/generic/InstructionFactory.java to add support for static interfaces
src/main/java/org/apache/bcel/generic/FieldGenOrMethodGen.java to improve Annotation support
It also contains two minor changes:

src/main/java/org/apache/bcel/classfile/Code.java to improve the toString() output.
src/main/java/org/apache/bcel/util/package.html to fix HTML for JDK 11